### PR TITLE
Bug fix for len function in diags.py

### DIFF
--- a/pyGSI/diags.py
+++ b/pyGSI/diags.py
@@ -41,7 +41,7 @@ class GSIdiag:
                          }
 
     def __len__(self):
-        return len(self.lats)
+        return self.data_df.shape[0]
 
     def _query_diag_type(self, df, diag_type, bias_correction):
         """


### PR DESCRIPTION
The len() function in diags.py used the "lats" variable which is no longer defined.  This is a simple fix to reinstate the len() functionality.