### PR TITLE
Add ability to read radiance Jacobians

### DIFF
--- a/pyGSI/diags.py
+++ b/pyGSI/diags.py
@@ -395,11 +395,11 @@ class Radiance(GSIdiag):
                         df_dict[var] = f.variables[var][:]
                 elif len(f.variables[var].shape) == 2:
                     if (var == 'Observation_Operator_Jacobian_stind'):
-                        jacstart = f.variables[var][:,:]
+                        jacstart = f.variables[var][:, :]
                     if (var == 'Observation_Operator_Jacobian_endind'):
-                        jacend = f.variables[var][:,:]
+                        jacend = f.variables[var][:, :]
                     if (var == 'Observation_Operator_Jacobian_val'):
-                        jac = f.variables[var][:,:]
+                        jac = f.variables[var][:, :]
                         jacobians_present = 1
 
         self.chan_info = chan_info
@@ -445,31 +445,33 @@ class Radiance(GSIdiag):
             # Hard-coded state variable names for now.  These are the
             # ones used in the v16 global GFS.  This needs to be added
             # to the netCDF files.
-            var_names=['sst','u','v','tv','q','oz','ql','qi']
+            var_names = ['sst', 'u', 'v' , 'tv', 'q', 'oz' , 'ql', 'qi']
 
-            # The jacstart and jacend arrays from the netCDF file 
+            # The jacstart and jacend arrays from the netCDF file
             # actually refer to internal GSI indicies.  We can use them
-            # to infer the length of each variable's section of the 
+            # to infer the length of each variable's section of the
             # Jacobian and set up indicies within the Jac array.
 
-            # Find the length of each variable's Jacobian assuming all 
+            # Find the length of each variable's Jacobian assuming all
             # channels/locs are the same (they are)
-            len_jacs=np.array(jacend[0,:]-jacstart[0,:]+1)
+            len_jacs = np.array(jacend[0, :] - jacstart[0, :] + 1)
             # Make jac_indices dataframe with positions of each Jacoboian
-            end_index=np.cumsum(len_jacs)-1
-            start_index=np.roll(end_index,1)
-            start_index[0]=0
-            jac_indices= pd.DataFrame([start_index,end_index],columns=var_names)
+            end_index = np.cumsum(len_jacs)-1
+            start_index = np.roll(end_index, 1)
+            start_index[0] = 0
+            jac_indices = pd.DataFrame([start_index, end_index], \
+                                       columns=var_names)
 
             jacobians = {}
             for var in var_names:
                 jac_range = jac_indices[var][1]-jac_indices[var][0]+1
                 jacobians[var] = \
-                    pd.DataFrame(jac[:,jac_indices[var][0]:jac_indices[var][1]+1],\
-                    columns=np.arange(jac_range))
-                jacobians[var].index=df_dict['Channel_Index']
-                jacobians[var].insert(0,'Latitude',df_dict['Latitude'])
-                jacobians[var].insert(1,'Longitude',df_dict['Longitude'])
+                    pd.DataFrame(jac[:,jac_indices[var][0]: \
+                                     jac_indices[var][1]+1], \
+                                     columns=np.arange(jac_range))
+                jacobians[var].index = df_dict['Channel_Index']
+                jacobians[var].insert(0, 'Latitude', df_dict['Latitude'])
+                jacobians[var].insert(1, 'Longitude', df_dict['Longitude'])
 
             del jac
 

--- a/pyGSI/diags.py
+++ b/pyGSI/diags.py
@@ -371,7 +371,7 @@ class Radiance(GSIdiag):
         # state variables to be defined as they are not present in the
         # diagnostic file.
         self.var_names = var_names or \
-                       ['sst', 'u', 'v', 'tv', 'q', 'oz', 'ql', 'qi']
+            ['sst', 'u', 'v', 'tv', 'q', 'oz', 'ql', 'qi']
         self.read_jac = read_jac
         self._read_obs()
 
@@ -409,10 +409,10 @@ class Radiance(GSIdiag):
                     if self.read_jac:
                         if (var ==
                            'Observation_Operator_Jacobian_stind'):
-                                jacstart = f.variables[var][:, :]
+                               jacstart = f.variables[var][:, :]
                         if (var ==
                            'Observation_Operator_Jacobian_endind'):
-                                jacend = f.variables[var][:, :]
+                               jacend = f.variables[var][:, :]
                         if (var == 'Observation_Operator_Jacobian_val'):
                             jac = f.variables[var][:, :]
                             jacobians_present = True

--- a/pyGSI/diags.py
+++ b/pyGSI/diags.py
@@ -445,7 +445,7 @@ class Radiance(GSIdiag):
             # Hard-coded state variable names for now.  These are the
             # ones used in the v16 global GFS.  This needs to be added
             # to the netCDF files.
-            var_names = ['sst', 'u', 'v' , 'tv', 'q', 'oz' , 'ql', 'qi']
+            var_names = ['sst', 'u', 'v', 'tv', 'q', 'oz', 'ql', 'qi']
 
             # The jacstart and jacend arrays from the netCDF file
             # actually refer to internal GSI indicies.  We can use them
@@ -459,16 +459,16 @@ class Radiance(GSIdiag):
             end_index = np.cumsum(len_jacs)-1
             start_index = np.roll(end_index, 1)
             start_index[0] = 0
-            jac_indices = pd.DataFrame([start_index, end_index], \
+            jac_indices = pd.DataFrame([start_index, end_index],
                                        columns=var_names)
 
             jacobians = {}
             for var in var_names:
                 jac_range = jac_indices[var][1]-jac_indices[var][0]+1
                 jacobians[var] = \
-                    pd.DataFrame(jac[:,jac_indices[var][0]: \
-                                     jac_indices[var][1]+1], \
-                                     columns=np.arange(jac_range))
+                    pd.DataFrame(jac[:, jac_indices[var][0]:
+                                     jac_indices[var][1]+1],
+                                 columns=np.arange(jac_range))
                 jacobians[var].index = df_dict['Channel_Index']
                 jacobians[var].insert(0, 'Latitude', df_dict['Latitude'])
                 jacobians[var].insert(1, 'Longitude', df_dict['Longitude'])

--- a/pyGSI/diags.py
+++ b/pyGSI/diags.py
@@ -350,19 +350,31 @@ class Conventional(GSIdiag):
 
 class Radiance(GSIdiag):
 
-    def __init__(self, path):
+    def __init__(self, path, var_names=None, read_jac=False):
         """
         Initialize a Radiance GSI diagnostic object
 
         Args:
-            path : (str) path to radiance GSI diagnostic object
+            path      : (str) path to radiance GSI diagnostic object
+            var_names : (string array, optional) Names of state 
+                        variables in Jacobians.
+            read_jac  : (bool, optional) Option to read in Jacobians.
+                        Default = False. 
         Returns:
             self : GSI diag radiance object containing the path
                    to extract data
         """
         super().__init__(path)
 
+        # The next two commands are for when the Jacobian is read in.
+        # This is optional and defaults to false.  It also requires the
+        # state variables to be defined as they are not present in the 
+        # diagnostic file.
+        self.var_names = var_names or \
+                         ['sst', 'u', 'v', 'tv', 'q', 'oz', 'ql', 'qi']
+        self.read_jac = read_jac
         self._read_obs()
+
         self.metadata['Diag File Type'] = 'radiance'
 
     def __str__(self):
@@ -375,7 +387,7 @@ class Radiance(GSIdiag):
         """
         df_dict = {}
         chan_info = {}
-        jacobians_present = 0
+        jacobians_present = False
         jacstart = {}
         jacend = {}
         jac = {}
@@ -394,13 +406,16 @@ class Radiance(GSIdiag):
                     elif len(f.variables[var][:]) == len(nobs):
                         df_dict[var] = f.variables[var][:]
                 elif len(f.variables[var].shape) == 2:
-                    if (var == 'Observation_Operator_Jacobian_stind'):
-                        jacstart = f.variables[var][:, :]
-                    if (var == 'Observation_Operator_Jacobian_endind'):
-                        jacend = f.variables[var][:, :]
-                    if (var == 'Observation_Operator_Jacobian_val'):
-                        jac = f.variables[var][:, :]
-                        jacobians_present = 1
+                    if self.read_jac:
+                        if (var == \
+                            'Observation_Operator_Jacobian_stind'):
+                            jacstart = f.variables[var][:, :]
+                        if (var == \
+                            'Observation_Operator_Jacobian_endind'):
+                            jacend = f.variables[var][:, :]
+                        if (var == 'Observation_Operator_Jacobian_val'):
+                            jac = f.variables[var][:, :]
+                            jacobians_present = True
 
         self.chan_info = chan_info
 
@@ -441,11 +456,7 @@ class Radiance(GSIdiag):
             'QC_Flag').unique().to_numpy()
 
         # Process Jacobians if present
-        if (jacobians_present == 1):
-            # Hard-coded state variable names for now.  These are the
-            # ones used in the v16 global GFS.  This needs to be added
-            # to the netCDF files.
-            var_names = ['sst', 'u', 'v', 'tv', 'q', 'oz', 'ql', 'qi']
+        if jacobians_present:
 
             # The jacstart and jacend arrays from the netCDF file
             # actually refer to internal GSI indicies.  We can use them
@@ -457,13 +468,12 @@ class Radiance(GSIdiag):
             len_jacs = np.array(jacend[0, :] - jacstart[0, :] + 1)
             # Make jac_indices dataframe with positions of each Jacoboian
             end_index = np.cumsum(len_jacs)-1
-            start_index = np.roll(end_index, 1)
+            start_index = np.roll(end_index, 1)+1
             start_index[0] = 0
             jac_indices = pd.DataFrame([start_index, end_index],
-                                       columns=var_names)
-
+                                       columns=self.var_names)
             jacobians = {}
-            for var in var_names:
+            for var in self.var_names:
                 jac_range = jac_indices[var][1]-jac_indices[var][0]+1
                 jacobians[var] = \
                     pd.DataFrame(jac[:, jac_indices[var][0]:
@@ -474,7 +484,7 @@ class Radiance(GSIdiag):
                 jacobians[var].insert(1, 'Longitude', df_dict['Longitude'])
 
             del jac
-
+            
             self.jacobians = jacobians
 
         self.data_df = df

--- a/pyGSI/diags.py
+++ b/pyGSI/diags.py
@@ -408,11 +408,11 @@ class Radiance(GSIdiag):
                 elif len(f.variables[var].shape) == 2:
                     if self.read_jac:
                         if (var ==
-                           'Observation_Operator_Jacobian_stind'):
-                               jacstart = f.variables[var][:, :]
+                            'Observation_Operator_Jacobian_stind'):
+                            jacstart = f.variables[var][:, :]
                         if (var ==
-                           'Observation_Operator_Jacobian_endind'):
-                               jacend = f.variables[var][:, :]
+                            'Observation_Operator_Jacobian_endind'):
+                            jacend = f.variables[var][:, :]
                         if (var == 'Observation_Operator_Jacobian_val'):
                             jac = f.variables[var][:, :]
                             jacobians_present = True

--- a/pyGSI/diags.py
+++ b/pyGSI/diags.py
@@ -408,11 +408,11 @@ class Radiance(GSIdiag):
                 elif len(f.variables[var].shape) == 2:
                     if self.read_jac:
                         if (var ==
-                        'Observation_Operator_Jacobian_stind'):
-                            jacstart = f.variables[var][:, :]
+                            'Observation_Operator_Jacobian_stind'):
+                                jacstart = f.variables[var][:, :]
                         if (var ==
-                        'Observation_Operator_Jacobian_endind'):
-                            jacend = f.variables[var][:, :]
+                            'Observation_Operator_Jacobian_endind'):
+                                jacend = f.variables[var][:, :]
                         if (var == 'Observation_Operator_Jacobian_val'):
                             jac = f.variables[var][:, :]
                             jacobians_present = True

--- a/pyGSI/diags.py
+++ b/pyGSI/diags.py
@@ -356,10 +356,10 @@ class Radiance(GSIdiag):
 
         Args:
             path      : (str) path to radiance GSI diagnostic object
-            var_names : (string array, optional) Names of state 
+            var_names : (string array, optional) Names of state
                         variables in Jacobians.
             read_jac  : (bool, optional) Option to read in Jacobians.
-                        Default = False. 
+                        Default = False.
         Returns:
             self : GSI diag radiance object containing the path
                    to extract data
@@ -368,10 +368,10 @@ class Radiance(GSIdiag):
 
         # The next two commands are for when the Jacobian is read in.
         # This is optional and defaults to false.  It also requires the
-        # state variables to be defined as they are not present in the 
+        # state variables to be defined as they are not present in the
         # diagnostic file.
         self.var_names = var_names or \
-                         ['sst', 'u', 'v', 'tv', 'q', 'oz', 'ql', 'qi']
+                       ['sst', 'u', 'v', 'tv', 'q', 'oz', 'ql', 'qi']
         self.read_jac = read_jac
         self._read_obs()
 
@@ -407,12 +407,12 @@ class Radiance(GSIdiag):
                         df_dict[var] = f.variables[var][:]
                 elif len(f.variables[var].shape) == 2:
                     if self.read_jac:
-                        if (var == \
-                            'Observation_Operator_Jacobian_stind'):
-                            jacstart = f.variables[var][:, :]
-                        if (var == \
-                            'Observation_Operator_Jacobian_endind'):
-                            jacend = f.variables[var][:, :]
+                        if (var ==
+                           'Observation_Operator_Jacobian_stind'):
+                                jacstart = f.variables[var][:, :]
+                        if (var ==
+                           'Observation_Operator_Jacobian_endind'):
+                                jacend = f.variables[var][:, :]
                         if (var == 'Observation_Operator_Jacobian_val'):
                             jac = f.variables[var][:, :]
                             jacobians_present = True

--- a/pyGSI/diags.py
+++ b/pyGSI/diags.py
@@ -408,10 +408,10 @@ class Radiance(GSIdiag):
                 elif len(f.variables[var].shape) == 2:
                     if self.read_jac:
                         if (var ==
-                            'Observation_Operator_Jacobian_stind'):
+                        'Observation_Operator_Jacobian_stind'):
                             jacstart = f.variables[var][:, :]
                         if (var ==
-                            'Observation_Operator_Jacobian_endind'):
+                        'Observation_Operator_Jacobian_endind'):
                             jacend = f.variables[var][:, :]
                         if (var == 'Observation_Operator_Jacobian_val'):
                             jac = f.variables[var][:, :]
@@ -484,7 +484,7 @@ class Radiance(GSIdiag):
                 jacobians[var].insert(1, 'Longitude', df_dict['Longitude'])
 
             del jac
-            
+
             self.jacobians = jacobians
 
         self.data_df = df

--- a/pyGSI/diags.py
+++ b/pyGSI/diags.py
@@ -407,12 +407,10 @@ class Radiance(GSIdiag):
                         df_dict[var] = f.variables[var][:]
                 elif len(f.variables[var].shape) == 2:
                     if self.read_jac:
-                        if (var ==
-                            'Observation_Operator_Jacobian_stind'):
-                                jacstart = f.variables[var][:, :]
-                        if (var ==
-                            'Observation_Operator_Jacobian_endind'):
-                                jacend = f.variables[var][:, :]
+                        if (var == 'Observation_Operator_Jacobian_stind'):
+                            jacstart = f.variables[var][:, :]
+                        if (var == 'Observation_Operator_Jacobian_endind'):
+                            jacend = f.variables[var][:, :]
                         if (var == 'Observation_Operator_Jacobian_val'):
                             jac = f.variables[var][:, :]
                             jacobians_present = True


### PR DESCRIPTION
[pyGSI/diags.py](https://github.com/ADCollard/PyGSI/blob/develop/pyGSI/diags.py) does not have the ability to read in two-dimensional arrays from the netCDF diag files.

I have created the ability to read in the Jacobian files that are currently an optional output from GSI.

If the Jacobians are present, the Jacobians are returned in the Radiance object as a dict containing individual Pandas dataframes for each state variable.  E.g.:

```
In [6]: diag = Radiance(diagnosticFile)

In [7]: diag.jacobians
Out[7]: 
{'sst':        Latitude   Longitude             0
 19   -87.248901    1.148580  1.261830e-20
 24   -87.248901    1.148580  2.818721e-05
 26   -87.248901    1.148580  2.168316e-05
 27   -87.248901    1.148580  9.418210e-25
 28   -87.248901    1.148580  2.205504e-05
 ...         ...         ...           ...
 2161  85.506104  350.627197  9.261398e-01
 2168  85.506104  350.627197  9.291455e-01
 2171  85.506104  350.627197  9.274320e-01
 2175  85.506104  350.627197  9.277828e-01
 2182  85.506104  350.627197  9.219809e-01
 
 [4737983 rows x 3 columns],
 'u':        Latitude   Longitude             0    1
 19   -87.248901    1.148580  1.261830e-20 -0.0
 24   -87.248901    1.148580  2.818721e-05 -0.0
 26   -87.248901    1.148580  2.168316e-05 -0.0
 27   -87.248901    1.148580  9.418210e-25 -0.0
 28   -87.248901    1.148580  2.205504e-05 -0.0
 ...         ...         ...           ...  ...
 2161  85.506104  350.627197  9.261398e-01  0.0
 2168  85.506104  350.627197  9.291455e-01  0.0
 2171  85.506104  350.627197  9.274320e-01  0.0
 2175  85.506104  350.627197  9.277828e-01  0.0
 2182  85.506104  350.627197  9.219809e-01  0.0
```
One issue is that the state variables are not present in the netCDF file,
so these are hard-coded for now. 
