### PR TITLE
bug fix to pyGSI/gsi_stat.py ; added aggregate rms/bias option to scripts/plot_gsi_stat_exp.py

### DIFF
--- a/pyGSI/gsi_stat.py
+++ b/pyGSI/gsi_stat.py
@@ -263,7 +263,7 @@ class GSIstat(object):
             if re.search(pattern, line):
                 header = line.strip()
                 header = re.sub('pbot', 'stat', header)
-                header = re.sub('2000.0', 'column', header)
+                header = re.sub('0.200E\+04', 'column', header)
                 pbots = np.array(header.split()[7:-1], dtype=np.float)
                 break
         if pbots is []:
@@ -272,7 +272,7 @@ class GSIstat(object):
         if header is None:
             print('No matching header for PS')
             sys.exit(1)
-
+        
         tmp = []
         pattern = r' o-g\s+(\d\d)\s+%s\s' % name
         for line in self._lines:

--- a/pyGSI/gsi_stat.py
+++ b/pyGSI/gsi_stat.py
@@ -263,7 +263,7 @@ class GSIstat(object):
             if re.search(pattern, line):
                 header = line.strip()
                 header = re.sub('pbot', 'stat', header)
-                header = re.sub('0.200E\+04', 'column', header)
+                header = re.sub('0.200E' + r'\+04', 'column', header)
                 pbots = np.array(header.split()[7:-1], dtype=np.float)
                 break
         if pbots is []:
@@ -272,7 +272,6 @@ class GSIstat(object):
         if header is None:
             print('No matching header for PS')
             sys.exit(1)
-        
         tmp = []
         pattern = r' o-g\s+(\d\d)\s+%s\s' % name
         for line in self._lines:

--- a/scripts/plot_gsi_stat_exp.py
+++ b/scripts/plot_gsi_stat_exp.py
@@ -29,7 +29,6 @@ def gen_figure(datadict, datatypestr, stattype, labels, sdate, edate, save, plot
     fig1 = plt.figure(figsize=(10, 8))
     plt.subplots_adjust(hspace=0.3)
     gs = gspec.GridSpec(1, 3)
-    #stattype = 'aggr' if datatypestr.lower() in ['bias', 'rmse'] else 'sum'
 
     for v, var in enumerate(obvars):
         xmin = 999
@@ -193,20 +192,20 @@ if __name__ == '__main__':
                 counts_var[i, :] = counts[exp][cycle][var].values[0]
             # Compute mean rms, bias
             rmses[exp]['mean'][var] = rmse_var.mean(axis=0)
-            biases[exp]['mean'][var] = bias_var.mean(axis=0)        
+            biases[exp]['mean'][var] = bias_var.mean(axis=0) 
             # Compute aggregate rms, bias
-            ar=np.asarray([])
-            ab=np.asarray([])
-            for j in range(np.ma.size(rmse_var,axis=1)):
-                r = rmse_var[:,j].squeeze()
-                b = bias_var[:,j].squeeze()
-                c = counts_var[:,j].squeeze()
-                if (np.sum(c)>0):
-                  ar = np.append(ar,np.sqrt(np.sum(np.multiply(c,r**2.))/np.sum(c)))
-                  ab = np.append(ab,np.sum(np.multiply(c,b))/np.sum(c))
+            ar = np.asarray([])
+            ab = np.asarray([])
+            for j in range(np.ma.size(rmse_var, axis=1)):
+                r = rmse_var[:, j].squeeze()
+                b = bias_var[:, j].squeeze()
+                c = counts_var[:, j].squeeze()
+                if (np.sum(c) > 0):
+                    ar = np.append(ar, np.sqrt(np.sum(np.multiply(c, r**2.))/np.sum(c)))
+                    ab = np.append(ab, np.sum(np.multiply(c, b))/np.sum(c))
                 else:
-                  ar = np.append(ar,np.nan)
-                  ab = np.append(ab,np.nan)
+                    ar = np.append(ar, np.nan)
+                    ab = np.append(ab, np.nan)
             rmses[exp]['aggr'][var] = ar
             biases[exp]['aggr'][var] = ab
             # Compute summed counts

--- a/scripts/plot_gsi_stat_exp.py
+++ b/scripts/plot_gsi_stat_exp.py
@@ -192,7 +192,7 @@ if __name__ == '__main__':
                 counts_var[i, :] = counts[exp][cycle][var].values[0]
             # Compute mean rms, bias
             rmses[exp]['mean'][var] = rmse_var.mean(axis=0)
-            biases[exp]['mean'][var] = bias_var.mean(axis=0) 
+            biases[exp]['mean'][var] = bias_var.mean(axis=0)
             # Compute aggregate rms, bias
             ar = np.asarray([])
             ab = np.asarray([])

--- a/scripts/plot_gsi_stat_exp.py
+++ b/scripts/plot_gsi_stat_exp.py
@@ -10,12 +10,13 @@ import numpy as np
 from pyGSI.gsi_stat import GSIstat
 
 it = 'it == 1'
+plottype = 'mean'
 obtypes = [120, 220]
 obvars = ['t', 'uv', 'q']
 levels = [1000, 900, 800, 600, 400, 300, 250, 200, 150, 100, 50, 0]
 
 
-def gen_figure(datadict, datatypestr, labels, sdate, edate, save, plotdir):
+def gen_figure(datadict, datatypestr, stattype, labels, sdate, edate, save, plotdir):
     # Line/marker colors for experiments ('k' is the first)
     mc = ['k', 'r', 'g', 'b', 'm', 'c', 'y']
 
@@ -28,7 +29,7 @@ def gen_figure(datadict, datatypestr, labels, sdate, edate, save, plotdir):
     fig1 = plt.figure(figsize=(10, 8))
     plt.subplots_adjust(hspace=0.3)
     gs = gspec.GridSpec(1, 3)
-    stattype = 'mean' if datatypestr.lower() in ['bias', 'rmse'] else 'sum'
+    #stattype = 'aggr' if datatypestr.lower() in ['bias', 'rmse'] else 'sum'
 
     for v, var in enumerate(obvars):
         xmin = 999
@@ -178,7 +179,9 @@ if __name__ == '__main__':
     # now aggregate stats
     for exp in labels:
         rmses[exp]['mean'] = {}
+        rmses[exp]['aggr'] = {}
         biases[exp]['mean'] = {}
+        biases[exp]['aggr'] = {}
         counts[exp]['sum'] = {}
         for var in obvars:
             rmse_var = np.empty([len(cycles), len(levels)])
@@ -188,12 +191,29 @@ if __name__ == '__main__':
                 rmse_var[i, :] = rmses[exp][cycle][var].values[0]
                 bias_var[i, :] = biases[exp][cycle][var].values[0]
                 counts_var[i, :] = counts[exp][cycle][var].values[0]
+            # Compute mean rms, bias
             rmses[exp]['mean'][var] = rmse_var.mean(axis=0)
-            biases[exp]['mean'][var] = bias_var.mean(axis=0)
+            biases[exp]['mean'][var] = bias_var.mean(axis=0)        
+            # Compute aggregate rms, bias
+            ar=np.asarray([])
+            ab=np.asarray([])
+            for j in range(np.ma.size(rmse_var,axis=1)):
+                r = rmse_var[:,j].squeeze()
+                b = bias_var[:,j].squeeze()
+                c = counts_var[:,j].squeeze()
+                if (np.sum(c)>0):
+                  ar = np.append(ar,np.sqrt(np.sum(np.multiply(c,r**2.))/np.sum(c)))
+                  ab = np.append(ab,np.sum(np.multiply(c,b))/np.sum(c))
+                else:
+                  ar = np.append(ar,np.nan)
+                  ab = np.append(ab,np.nan)
+            rmses[exp]['aggr'][var] = ar
+            biases[exp]['aggr'][var] = ab
+            # Compute summed counts
             counts[exp]['sum'][var] = counts_var.sum(axis=0)
 
     # make figures
-    gen_figure(rmses, 'RMSE', labels, sdate, edate, save_figure, args.plotdir)
-    gen_figure(biases, 'Bias', labels, sdate, edate, save_figure, args.plotdir)
-    gen_figure(counts, 'Count', labels, sdate, edate,
+    gen_figure(rmses, 'RMSE', plottype, labels, sdate, edate, save_figure, args.plotdir)
+    gen_figure(biases, 'Bias', plottype, labels, sdate, edate, save_figure, args.plotdir)
+    gen_figure(counts, 'Count', 'sum', labels, sdate, edate,
                save_figure, args.plotdir)


### PR DESCRIPTION
**pyGSI/gsi_stat.py**:
L266: the search/replace string for header has to be a FORTRAN-formatted expression, rather than a simple float. So '2000.0' needs to be replaced with '0.200E' + r'\+04', in order for the header to read 'column' for this entry.

**scripts/plot_gsi_stat_exp.py**: 
L13: added variable plottype to allow for choosing either the mean rms/bias ('mean') or aggregate rms/bias ('aggr') in gen_figure()
L31-32: removed the implicit declaration for stattype, now stattype is user-defined in call to gen_figure() via plottype
L182,184: added aggregate rms and bias scores to rmses and biases dictionaries
L194-212: aggregate rms/bias scores are computed, being careful to assign np.nan to any level with counts=0
L216-218: gen_figure() is passed plottype variable to plot either mean or aggregate rms/bias scores