### PR TITLE
Bug fix for _get_conv() to pull appropriate ptop, pbot based on variable

### DIFF
--- a/pyGSI/gsi_stat.py
+++ b/pyGSI/gsi_stat.py
@@ -247,11 +247,13 @@ class GSIstat(object):
         # Get pressure levels
         ptops = []
         pattern = r'o-g\s+ptop\s'
-        for line in self._lines:
+        for i in range(len(self._lines)):
+            line = self._lines[i]
             if re.search(pattern, line):
-                header = line.strip()
-                ptops = np.array(header.split()[2:-1], dtype=np.float)
-                break
+                if re.search(' '+name+' ', self._lines[i+2]):
+                    header = line.strip()
+                    ptops = np.array(header.split()[2:-1], dtype=np.float)
+                    break
         if ptops is []:
             print(f'No matching ptop for {name}')
             sys.exit(1)
@@ -259,13 +261,15 @@ class GSIstat(object):
         header = None
         pbots = []
         pattern = r'o-g\s+it\s+obs\s+use\s+typ\s+styp\s+pbot\s'
-        for line in self._lines:
+        for i in range(len(self._lines)):
+            line = self._lines[i]
             if re.search(pattern, line):
-                header = line.strip()
-                header = re.sub('pbot', 'stat', header)
-                header = re.sub('0.200E' + r'\+04', 'column', header)
-                pbots = np.array(header.split()[7:-1], dtype=np.float)
-                break
+                if re.search(' '+name+' ', self._lines[i+2]):
+                    header = line.strip()
+                    header = re.sub('pbot', 'stat', header)
+                    header = re.sub('0.200E' + r'\+04', 'column', header)
+                    pbots = np.array(header.split()[7:-1], dtype=np.float)
+                    break
         if pbots is []:
             print(f'No matching pbot for {name}')
             sys.exit(1)


### PR DESCRIPTION
The header search in _get_conv() will automatically break after finding the first header matching the pattern, which is always the header for the 'uv' variable type. While 'uv' and 't' variable types have identical headers, the header for the 'q' variable type is different, with different ptop and pbot values. Ex:

'uv' or 't' header:
```
 o-g                          ptop  0.100E+04  0.900E+03  0.800E+03  0.600E+03  0.400E+03  0.300E+03  0.250E+03  0.200E+03  0.150E+03  0.100E+03  0.500E+02  0.000E+00
 o-g it     obs use typ styp  pbot  0.120E+04  0.100E+04  0.900E+03  0.800E+03  0.600E+03  0.400E+03  0.300E+03  0.250E+03  0.200E+03  0.150E+03  0.100E+03  0.200E+04
```
'q' header:
```
 o-g                          ptop  0.100E+04  0.950E+03  0.900E+03  0.850E+03  0.800E+03  0.700E+03  0.600E+03  0.500E+03  0.400E+03  0.300E+03  0.000E+00  0.000E+00
 o-g it     obs use typ styp  pbot  0.120E+04  0.100E+04  0.950E+03  0.900E+03  0.850E+03  0.800E+03  0.700E+03  0.600E+03  0.500E+03  0.400E+03  0.300E+03  0.200E+04
```
The 'q' header has the same number of pressure levels, but they are distributed differently. _get_conv() incorrectly aliases 'q' data onto the 'uv'/'t' vertical levels by replacing the 'q' header information with the default 'uv' header information. To fix this, the search is modified into two stages:
stage-1: Find a line matching the header string format
stage-2: Determine if the line two lines underneath the line from stage-1 contains an appropriate variable type (' uv ', ' t ', or ' q ', with the whitespace intentionally surrounding the variable name)
If a line satisfies both criteria, it is taken as the appropriate header for the variable type being extracted. The appropriate changes are made to:
Lines 250, 252-254: search for ptop
Lines 262, 264-268: search for pbot and header