### PR TITLE
Feature/obspace diagnostics

### DIFF
--- a/pyGSI/ensemble_diags.py
+++ b/pyGSI/ensemble_diags.py
@@ -86,10 +86,10 @@ def time_trace(
     cr = _np.zeros(shape=(n_ob_type, n_expt, 24))
     ser = _np.zeros(shape=(n_ob_type, n_expt, 24))
 
-    sum_innov = _np.zeros(shape=(n_expt, 24))
-    sum_innovsq = _np.zeros(shape=(n_expt, 24))
-    sum_fcst_ens_var = _np.zeros(shape=(n_expt, 24))
-    sum_ob_err_var = _np.zeros(shape=(n_expt, 24))
+    sum_innov = _np.zeros(shape=(n_ob_type, n_expt, 24))
+    sum_innovsq = _np.zeros(shape=(n_ob_type, n_expt, 24))
+    sum_fcst_ens_var = _np.zeros(shape=(n_ob_type, n_expt, 24))
+    sum_ob_err_var = _np.zeros(shape=(n_ob_type, n_expt, 24))
 
     bbreak = False
 
@@ -233,28 +233,29 @@ def time_trace(
                 innov = ob - fcst_ens_mean
                 num_obs_total[i_o, i_e, hour] = num_obs_total[i_o, i_e, hour] + itot
                 num_obs_assim[i_o, i_e, hour] = num_obs_assim[i_o, i_e, hour] + iasm
-                sum_innov[i_e, hour] = sum_innov[i_e, hour] + _np.sum(innov)
-                sum_innovsq[i_e, hour] = sum_innovsq[i_e, hour] + _np.sum(innov**2)
-                sum_fcst_ens_var[i_e, hour] = sum_fcst_ens_var[i_e, hour] + _np.sum(fcst_ens_var)
-                sum_ob_err_var[i_e, hour] = sum_ob_err_var[i_e, hour] + _np.sum(error_var)
+                sum_innov[i_o, i_e, hour] = sum_innov[i_o, i_e, hour] + _np.sum(innov)
+                sum_innovsq[i_o, i_e, hour] = sum_innovsq[i_o, i_e, hour] + _np.sum(innov**2)
+                sum_fcst_ens_var[i_o, i_e, hour] = sum_fcst_ens_var[i_o, i_e, hour] + _np.sum(fcst_ens_var)
+                sum_ob_err_var[i_o, i_e, hour] = sum_ob_err_var[i_o, i_e, hour] + _np.sum(error_var)
 
                 # end n_times
 
                 if num_obs_assim[i_o, i_e, hour] > 0:
-                    mean_innov = sum_innov[i_e, hour] / num_obs_assim[i_o, i_e, hour]
+                    mean_innov = sum_innov[i_o, i_e, hour] / num_obs_assim[i_o, i_e, hour]
                     bias[i_o, i_e, hour] = -1 * mean_innov
-                    rms[i_o, i_e, hour] = _np.sqrt(sum_innovsq[i_e, hour] / num_obs_assim[i_o, i_e, hour])
-                    mean_ob_err_var = sum_ob_err_var[i_e, hour] / num_obs_assim[i_o, i_e, hour]
+                    rms[i_o, i_e, hour] = _np.sqrt(sum_innovsq[i_o, i_e, hour] / num_obs_assim[i_o, i_e, hour])
+                    mean_ob_err_var = sum_ob_err_var[i_o, i_e, hour] / num_obs_assim[i_o, i_e, hour]
                     ob_error[i_o, i_e, hour] = _np.sqrt(mean_ob_err_var)
 
                 if num_obs_assim[i_o, i_e, hour] > 1:
-                    innov_var = (sum_innovsq[i_e, hour] - num_obs_assim[i_o, i_e, hour] * mean_innov**2) / (num_obs_assim[i_o, i_e, hour] - 1.0)
+                    innov_var = (sum_innovsq[i_o, i_e, hour] - num_obs_assim[i_o, i_e, hour] * mean_innov**2) / (num_obs_assim[i_o, i_e, hour] - 1.0)
                     std_dev[i_o, i_e, hour] = _np.sqrt(innov_var)
-                    mean_fcst_var = sum_fcst_ens_var[i_e, hour] / num_obs_assim[i_o, i_e, hour]
+                    mean_fcst_var = sum_fcst_ens_var[i_o, i_e, hour] / num_obs_assim[i_o, i_e, hour]
                     spread[i_o, i_e, hour] = _np.sqrt(mean_fcst_var)
                     total_spread[i_o, i_e, hour] = _np.sqrt(mean_ob_err_var + mean_fcst_var)
                     cr[i_o, i_e, hour] = (total_spread[i_o, i_e, hour] / rms[i_o, i_e, hour]) ** 2
                     ser[i_o, i_e, hour] = spread[i_o, i_e, hour] / rms[i_o, i_e, hour]
+
 
                 del errorinv
                 del error

--- a/pyGSI/ensemble_diags.py
+++ b/pyGSI/ensemble_diags.py
@@ -5,7 +5,7 @@ import emcpy.io as _io
 import pyGSI.filter_obs as _filter_obs
 
 
-def ensemble_obspace_diag(
+def time_trace(
     datapath,
     date1,
     date2,

--- a/pyGSI/ensemble_diags.py
+++ b/pyGSI/ensemble_diags.py
@@ -256,7 +256,6 @@ def time_trace(
                     cr[i_o, i_e, hour] = (total_spread[i_o, i_e, hour] / rms[i_o, i_e, hour]) ** 2
                     ser[i_o, i_e, hour] = spread[i_o, i_e, hour] / rms[i_o, i_e, hour]
 
-
                 del errorinv
                 del error
                 del itot

--- a/pyGSI/ensemble_diags.py
+++ b/pyGSI/ensemble_diags.py
@@ -104,6 +104,11 @@ def time_trace(
             continue  # As of right now, the rrfs only runs the EnKF at 18-23Z so skip those off times
         for ob_type in ob_types:
             i_o = ob_types.index(ob_type)
+            # https://emc.ncep.noaa.gov/mmb/data_processing/prepbufr.doc/table_2.htm
+            if ob_type == "u" or ob_type == "v":
+                codes = codes_uv
+            elif ob_type == "t" or ob_type == "q":
+                codes = codes_tq
             for expt_name in expt_names:
                 print(f"{date} {expt_name} {ob_type}")
                 i_e = expt_names.index(expt_name)
@@ -128,7 +133,6 @@ def time_trace(
                         bbreak = True  # need to break here and one loop higher.
                         break
 
-
                     nc = Dataset(diagfile)
                     use = nc["Analysis_Use_Flag"][:]
                     use[use < 1] = 0
@@ -152,18 +156,12 @@ def time_trace(
                         diagfile = _os.path.join(datapath, f"{expt_name}/{date}/mem{memid}/diag_conv_{ob_type}_ges.{date}.nc4")
                     nc = Dataset(diagfile)
                     if mem == 1:
-                        use = analysis_use  # preemptively read the diag files to get used by all members.
+                        use = analysis_use
                         code = nc["Observation_Type"][:]
                         lat = nc["Latitude"][:]
                         lon = nc["Longitude"][:]
                         pressure = nc["Pressure"][:]
                         errorinv = nc["Errinv_Final"][:]
-
-                        # https://emc.ncep.noaa.gov/mmb/data_processing/prepbufr.doc/table_2.htm
-                        if ob_type == "u" or ob_type == "v":
-                            codes = codes_uv
-                        elif ob_type == "t" or ob_type == "q":
-                            codes = codes_tq
 
                         if ob_type == "u":
                             ob = nc["u_Observation"][:]
@@ -201,7 +199,6 @@ def time_trace(
                         itot = len(ob)
                         ob = ob[used]
                         iasm = len(ob)
-
                         # end if mem==1
 
                     if ob_type == "u":

--- a/pyGSI/filter_obs.py
+++ b/pyGSI/filter_obs.py
@@ -1,0 +1,94 @@
+import numpy as _np
+
+
+def filter_obs(
+    code,
+    codes,
+    errorinv,
+    lat,
+    lon,
+    pressure,
+    use,
+    hem=None,
+    p_max=1050.0,
+    p_min=100.0,
+    lat_max=90.0,
+    lat_min=0.0,
+    lon_max=360.0,
+    lon_min=0.0,
+    error_max=40.0,
+    error_min=0.000001,
+):
+    """
+    Create the bool array used to filter by. Considers obs filtered by the use flag,
+    max/min pressure, latitude, longitude, and errors along with filtering by bufr
+    code (e.g., 187 or 287).
+
+    netCDF Args:
+        code     : (array int) bufr ob codes from netCDF file <Observation_Type>
+        codes    : (array int) bufr ob codes to filter by, see link
+                   https://emc.ncep.noaa.gov/mmb/data_processing/prepbufr.doc/table_2.htm
+        errorinv : (array float) from netCDF file <Errinv_Final>
+        lat      : (array float) from netCDF file <Latitude>
+        lon      : (array float) from netCDF file <Longitude>
+        pressure : (array float) from netCDF file <Pressure>
+
+     Filtering Args:
+        use      : (int)   use flag for observation 1=used
+        p_max    : (float) maximum pressure (mb) for including observation in calculations
+        p_min    : (float) minimum pressure (mb) for including observation in calculations
+        lat_max  : (float) maximum latitude (deg N) for including observation in calculations
+        lat_min  : (float) minimum latitude (deg N) for including observation in calculations
+        lon_max  : (float) maximum latitude (deg E) for including observation in calculations
+        lon_min  : (float) minimum latitude (deg E) for including observation in calculations
+        error_max: (float) maximum error standard deviation for including observation in calculations
+        error_min: (float) minimum error standard deviation for including observation in calculations
+
+    Returns:
+        used : (array bool) observations to consider after all filtering
+    """
+
+    # if hem is provided, override the lat/lon min/maxes
+    if (hem == "GL"):
+        lat_max = 90.0
+        lat_min = -90.0
+        lon_max = 360.0
+        lon_min = 0.0
+    elif (hem == "NH"):
+        lat_max = -30.0
+        lat_min = -90.0
+        lon_max = 360.0
+        lon_min = 0.0
+    elif (hem == "TR"):
+        lat_max = 30.0
+        lat_min = -30.0
+        lon_max = 360.0
+        lon_min = 0.0
+    elif (hem == "SH"):
+        lat_max = 90.0
+        lat_min = 30.0
+        lon_max = 360.0
+        lon_min = 0.0
+    elif (hem == "CONUS"):
+        lat_max = 50.0
+        lat_min = 27.0
+        lon_max = 295.0
+        lon_min = 235.0
+    elif hem is not None:
+        msg = 'hemispheres must be: GLOBAL, NH, TR, SH, CONUS, or None'
+        raise ValueError(msg)
+
+    used = code == codes[0]  # initialize used
+    for cd in codes:
+        used = _np.logical_or(used, code == cd)  # loop over all codes provided
+
+    error_min_inv = 1.0 / error_min
+    error_max_inv = 1.0 / error_max
+    # consider where use flag==1 and bound by error/lat/lon/pres
+    used = _np.logical_and(used, use == 1)
+    used = _np.logical_and(used, _np.logical_and(errorinv <= error_min_inv, errorinv >= error_max_inv))
+    used = _np.logical_and(used, _np.logical_and(lat >= lat_min, lat <= lat_max))
+    used = _np.logical_and(used, _np.logical_and(lon >= lon_min, lon <= lon_max))
+    used = _np.logical_and(used, _np.logical_and(pressure >= p_min, pressure <= p_max))
+
+    return used

--- a/pyGSI/obspace.py
+++ b/pyGSI/obspace.py
@@ -55,7 +55,7 @@ def ensemble_obspace_diag(
       std_dev       : (array float) standard deviation of (F-O)
       spread        : (array float) ensemble spread (standard deviation)
       ob_error      : (array float) observation error standard deviation
-      total_spread  : (array float) total spread (standard deviation) 
+      total_spread  : (array float) total spread (standard deviation)
       num_obs_total : (array float) total number of observations
       num_obs_assim : (array float) total number of observations assimilated
       cr            : (array float) consistency ratio (total spread/rmsi)**2
@@ -189,10 +189,11 @@ def ensemble_obspace_diag(
                     mem = mem + 1
                     # end while n_mem
 
-                try: # if we broke out of the loop above before, because we were missing a mem.
-                     # this will break out of the loop here too.
+                # if we broke out of the loop above before, because we were missing a mem.
+                # this will break out of the loop here too.
+                try:
                     error_var = error**2
-                except:
+                except ValueError:
                     break
 
                 fcst_ens_mean = fcst_ens_mean / n_mem
@@ -237,8 +238,6 @@ def ensemble_obspace_diag(
                 del lon
                 del pressure
                 del use
-                #del 
-                #del 
 
             # end do n_expt
         # end do n_ob_type

--- a/pyGSI/obspace.py
+++ b/pyGSI/obspace.py
@@ -1,0 +1,230 @@
+import numpy as _np
+import os as _os
+import emcpy.utils.dateutils as _dateutils
+import emcpy.io as _io
+import pyGSI.filter_obs as _filter_obs
+
+
+def ensemble_obspace_diag(
+    datapath,
+    date1,
+    date2,
+    expt_names,
+    n_mem,
+    skip_enkf_hours=[],
+    ob_types=["u"],
+    codes_uv=[187],
+    codes_tq=[287],
+    hem=None,
+    p_max=1050.0,
+    p_min=100.0,
+    lat_max=90.0,
+    lat_min=0.0,
+    lon_max=360.0,
+    lon_min=0.0,
+    error_max=40.0,
+    error_min=0.000001,
+):
+    """
+    Computes observation space stats into 3D arrays (n_ob_type, n_expt, 24) and plots the stats as a
+    function of hour of day.
+
+    Args:
+      datapath        : (str) netCDF filename
+      date1           : (str "YYYYMMDDHH") start date
+      date2           : (str "YYYYMMDDHH") end date
+      skip_enkf_hours : (list of int) hours (UTC) to skip for enkf
+      expt_names      : (list of str) experiment names
+      n_mem           : (int) number of ensemble members
+      ob_types        : (list of str) observation types (u,v,t,q,etc.)
+      codes_uv        : (list of int) uv bufr codes used to filter obs
+      codes_tq        : (list of int) tq bufr codes used to filter obs
+      p_max           : (float) maximum pressure (mb) for including observation in calculations
+      p_min           : (float) minimum pressure (mb) for including observation in calculations
+      lat_max         : (float) maximum latitude (deg N) for including observation in calculations
+      lat_min         : (float) minimum latitude (deg N) for including observation in calculations
+      lon_max         : (float) maximum latitude (deg E) for including observation in calculations
+      lon_min         : (float) minimum latitude (deg E) for including observation in calculations
+      error_max       : (float) maximum error standard deviation for including observation in calculations
+      error_min       : (float) minimum error standard deviation for including observation in calculations
+
+    Returns:
+      dates         : (list str) list of date strings of the form YYYYMMDDHH based on date1 and date2
+      bias          : (array float) mean of (forecast - observation)
+      rms           : (array float) rms of (F-O)
+      std_dev       : (array float) standard deviation of (F-O)
+      rmse          : (array float) total spread (standard deviation)
+      spread        : (array float) ensemble spread (standard deviation)
+      ob_error      : (array float) observation error standard deviation
+      total_spread  : (array float) rms of (O-Omf) = rmse of ensemble mean fcst
+      num_obs_total : (array float) total number of observations
+      num_obs_assim : (array float) total number of observations assimilated
+      cr            : (array float) consistency ratio (total spread/rmsi)**2
+      ser           : (array float) spread error ratio (intraensemble std_dev/ rmse of ensemble mean fcst)
+
+    References:
+        consistency ratio (cr)
+          a) https://journals.ametsoc.org/view/journals/atot/26/5/2008jtecha1156_1.xml (eq 3.4)
+          b) https://journals.ametsoc.org/view/journals/mwre/150/8/MWR-D-21-0289.1.xml (eq 7)
+        spread error ratio (ser)
+          a) https://agupubs.onlinelibrary.wiley.com/doi/full/10.1002/2013GL057630 (eq 1)
+        bufr codes
+          a) https://emc.ncep.noaa.gov/mmb/data_processing/prepbufr.doc/table_2.htm
+    """
+
+    hours = 24
+    dates = _dateutils.daterange(date1, date2, 1)
+    n_expt = len(expt_names)
+    n_ob_type = len(ob_types)
+    bias = _np.zeros(shape=(n_ob_type, n_expt, 24))
+    rms = _np.zeros(shape=(n_ob_type, n_expt, 24))
+    std_dev = _np.zeros(shape=(n_ob_type, n_expt, 24))
+    rmse = _np.zeros(shape=(n_ob_type, n_expt, 24))
+    spread = _np.zeros(shape=(n_ob_type, n_expt, 24))
+    total_spread = _np.zeros(shape=(n_ob_type, n_expt, 24))
+    ob_error = _np.zeros(shape=(n_ob_type, n_expt, 24))
+    num_obs_assim = _np.zeros(shape=(n_ob_type, n_expt, 24))
+    num_obs_total = _np.zeros(shape=(n_ob_type, n_expt, 24))
+    cr = _np.zeros(shape=(n_ob_type, n_expt, 24))
+    ser = _np.zeros(shape=(n_ob_type, n_expt, 24))
+
+    sum_innov = _np.zeros(shape=(n_expt, 24))
+    sum_innovsq = _np.zeros(shape=(n_expt, 24))
+    sum_fcst_ens_var = _np.zeros(shape=(n_expt, 24))
+    sum_ob_err_var = _np.zeros(shape=(n_expt, 24))
+
+    for date in dates:
+        times = _dateutils.datetohrs(date)
+        pdy = str(date[0:8])
+        hour = int(str(date[8:10]))
+        if any(item == hour for item in skip_enkf_hours):
+            continue  # As of right now, the rrfs only runs the EnKF at 18-23Z so skip those off times
+        for ob_type in ob_types:
+            i_o = ob_types.index(ob_type)
+            for expt_name in expt_names:
+                print("%s %s %s" % (date, expt_name, ob_type))
+                i_e = expt_names.index(expt_name)
+                mem = 1
+                while mem <= n_mem:
+                    memid = str(mem).zfill(4)
+                    if ob_type == "u" or ob_type == "v":
+                        obsfile = _os.path.join(datapath, "%s/%s/mem%s/diag_conv_uv_ges.%s.nc4" % (expt_name, date, memid, date))
+                    else:
+                        obsfile = _os.path.join(datapath, "%s/%s/mem%s/diag_conv_%s_ges.%s.nc4" % (expt_name, date, memid, ob_type, date))
+
+                    exists = _os.path.exists(obsfile)
+                    if not exists:
+                        print("diag file for %s mem%s %s doesn't exist." % (expt_name, str(mem).zfill(4), str(date)))
+                        mem = mem + 1
+                        continue
+
+                    if mem == 1:
+                        code = _io.netCDF.read_netCDF_var(obsfile, "Observation_Type", oneD=True)
+                        lat = _io.netCDF.read_netCDF_var(obsfile, "Latitude", oneD=True)
+                        lon = _io.netCDF.read_netCDF_var(obsfile, "Longitude", oneD=True)
+                        pressure = _io.netCDF.read_netCDF_var(obsfile, "Pressure", oneD=True)
+                        use = _io.netCDF.read_netCDF_var(obsfile, "Analysis_Use_Flag", oneD=True)
+                        errorinv = _io.netCDF.read_netCDF_var(obsfile, "Errinv_Final", oneD=True)
+
+                        # https://emc.ncep.noaa.gov/mmb/data_processing/prepbufr.doc/table_2.htm
+                        if ob_type == "u" or ob_type == "v":
+                            codes = codes_uv
+                        elif ob_type == "t" or ob_type == "q":
+                            codes = codes_tq
+
+                        if ob_type == "u":
+                            ob = _io.netCDF.read_netCDF_var(obsfile, "u_Observation", oneD=True)
+                        elif ob_type == "v":
+                            ob = _io.netCDF.read_netCDF_var(obsfile, "v_Observation", oneD=True)
+                        else:
+                            ob = _io.netCDF.read_netCDF_var(obsfile, "Observation", oneD=True)
+
+                        if ob_type == "q":
+                            ob = 1000.0 * ob  # convert from kg/kg to g/kg
+                            errorinv = errorinv / 1000.0  # convert from kg/kg to g/kg
+
+                        # consider where use flag==1 and bound by error/lat/lon/pres
+                        used = _filter_obs.filter_obs(
+                            code,
+                            codes,
+                            errorinv,
+                            lat,
+                            lon,
+                            pressure,
+                            use,
+                            hem,
+                            p_max=p_max,
+                            p_min=p_min,
+                            lat_max=lat_max,
+                            lat_min=lat_min,
+                            lon_max=lon_max,
+                            lon_min=lon_min,
+                            error_max=error_max,
+                            error_min=error_min,
+                        )
+
+                        errorinv = errorinv[used]
+                        error = 1.0 / errorinv
+                        itot = len(ob)
+                        ob = ob[used]
+                        iasm = len(ob)
+
+                        # end if mem==1
+
+                    if ob_type == "u":
+                        omf = _io.netCDF.read_netCDF_var(obsfile, "u_Obs_Minus_Forecast_adjusted", oneD=True)
+                    elif ob_type == "v":
+                        omf = _io.netCDF.read_netCDF_var(obsfile, "v_Obs_Minus_Forecast_adjusted", oneD=True)
+                    else:
+                        omf = _io.netCDF.read_netCDF_var(obsfile, "Obs_Minus_Forecast_adjusted", oneD=True)
+                    if ob_type == "q":
+                        omf = 1000.0 * omf  # convert from kg/kg to g/kg
+
+                    omf = omf[used]
+
+                    if mem == 1:
+                        fcst_ens_mean = ob - omf
+                        fcst_ens_var = (ob - omf) ** 2
+                    else:
+                        fcst_ens_mean = fcst_ens_mean + ob - omf
+                        fcst_ens_var = fcst_ens_var + (ob - omf) ** 2
+                    mem = mem + 1
+                    # end while n_mem
+
+                error_var = error**2
+                fcst_ens_mean = fcst_ens_mean / n_mem
+                if n_mem > 1:
+                    fcst_ens_var = (fcst_ens_var - n_mem * fcst_ens_mean**2) / (n_mem - 1)
+                else:
+                    fcst_ens_var = 0.0
+                innov = ob - fcst_ens_mean
+                num_obs_total[i_o, i_e, hour] = num_obs_total[i_o, i_e, hour] + itot
+                num_obs_assim[i_o, i_e, hour] = num_obs_assim[i_o, i_e, hour] + iasm
+                sum_innov[i_e, hour] = sum_innov[i_e, hour] + _np.sum(innov)
+                sum_innovsq[i_e, hour] = sum_innovsq[i_e, hour] + _np.sum(innov**2)
+                sum_fcst_ens_var[i_e, hour] = sum_fcst_ens_var[i_e, hour] + _np.sum(fcst_ens_var)
+                sum_ob_err_var[i_e, hour] = sum_ob_err_var[i_e, hour] + _np.sum(error_var)
+
+                # end n_times
+
+                if num_obs_assim[i_o, i_e, hour] > 0:
+                    mean_innov = sum_innov[i_e, hour] / num_obs_assim[i_o, i_e, hour]
+                    bias[i_o, i_e, hour] = -1 * mean_innov
+                    rms[i_o, i_e, hour] = _np.sqrt(sum_innovsq[i_e, hour] / num_obs_assim[i_o, i_e, hour])
+                    mean_ob_err_var = sum_ob_err_var[i_e, hour] / num_obs_assim[i_o, i_e, hour]
+                    ob_error[i_o, i_e, hour] = _np.sqrt(mean_ob_err_var)
+                    rmse[i_o, i_e, hour] = _np.sqrt(sum_fcst_ens_var[i_e, hour] / num_obs_assim[i_o, i_e, hour])
+
+                if num_obs_assim[i_o, i_e, hour] > 1:
+                    innov_var = (sum_innovsq[i_e, hour] - num_obs_assim[i_o, i_e, hour] * mean_innov**2) / (num_obs_assim[i_o, i_e, hour] - 1.0)
+                    std_dev[i_o, i_e, hour] = _np.sqrt(innov_var)
+                    mean_fcst_var = sum_fcst_ens_var[i_e, hour] / num_obs_assim[i_o, i_e, hour]
+                    spread[i_o, i_e, hour] = _np.sqrt(mean_fcst_var)
+                    total_spread[i_o, i_e, hour] = _np.sqrt(mean_ob_err_var + mean_fcst_var)
+                    cr[i_o, i_e, hour] = (total_spread[i_o, i_e, hour] / rms[i_o, i_e, hour]) ** 2
+                    ser[i_o, i_e, hour] = spread[i_o, i_e, hour] / rmse[i_o, i_e, hour]
+
+            # end do n_expt
+        # end do n_ob_type
+
+    return dates, bias, rms, std_dev, rmse, spread, ob_error, total_spread, num_obs_total, num_obs_assim, cr, ser

--- a/pyGSI/obspace.py
+++ b/pyGSI/obspace.py
@@ -3,7 +3,6 @@ import os as _os
 import emcpy.utils.dateutils as _dateutils
 import emcpy.io as _io
 import pyGSI.filter_obs as _filter_obs
-import pdb
 
 
 def ensemble_obspace_diag(
@@ -107,8 +106,6 @@ def ensemble_obspace_diag(
                 i_e = expt_names.index(expt_name)
 
                 # Initial read of all the ensemble diag files to get a common list of used observations.
-                # I don't think there is any way around doing this...
-
                 # Preemptively read analysis use flag of all ensemble diags. All ensembles will not
                 # necessarily use the same observations (gross errors checks etc.). Change all use
                 # values that are less than 1 to 0, then multiply each use numpy array by the previous
@@ -121,23 +118,25 @@ def ensemble_obspace_diag(
                     else:
                         diagfile = _os.path.join(datapath, f"{expt_name}/{date}/mem{memid}/diag_conv_{ob_type}_ges.{date}.nc4")
                     # Check for if there are any diag files for a particular cycle date.
+                    # If there are none, move to the next cycle date.
                     exists = _os.path.exists(diagfile)
                     if not exists:
                         print(f"diag file for {expt_name} mem{mem:0>4} {date} doesn't exist. Skipping {date}.")
-                        bbreak=True  # need to break here and one loop higher.
+                        bbreak = True  # need to break here and one loop higher.
                         break
 
                     use = _io.netCDF.read_netCDF_var(diagfile, "Analysis_Use_Flag", oneD=True)
                     use[use < 1] = 0
-                    if(mem == 1):
+                    if mem == 1:
                         analysis_use = use
                     else:
                         analysis_use = analysis_use * use
                     mem = mem + 1
+                    # End of initial read of all ensemble diag files.
 
-                if(bbreak):
-                    bbreak=False  # reset break
-                    break
+                if bbreak:
+                    bbreak = False  # reset break
+                    break  # break and move to next cycle time.
 
                 mem = 1
                 while mem <= n_mem:
@@ -151,9 +150,7 @@ def ensemble_obspace_diag(
                         lat = _io.netCDF.read_netCDF_var(diagfile, "Latitude", oneD=True)
                         lon = _io.netCDF.read_netCDF_var(diagfile, "Longitude", oneD=True)
                         pressure = _io.netCDF.read_netCDF_var(diagfile, "Pressure", oneD=True)
-                        #use = _io.netCDF.read_netCDF_var(diagfile, "Analysis_Use_Flag", oneD=True)
-                        #use[use < 1] = 0
-                        use = analysis_use # preemptively read the diag files to get used by all members.
+                        use = analysis_use  # preemptively read the diag files to get used by all members.
                         errorinv = _io.netCDF.read_netCDF_var(diagfile, "Errinv_Final", oneD=True)
 
                         # https://emc.ncep.noaa.gov/mmb/data_processing/prepbufr.doc/table_2.htm

--- a/pyGSI/obspace.py
+++ b/pyGSI/obspace.py
@@ -100,19 +100,19 @@ def ensemble_obspace_diag(
         for ob_type in ob_types:
             i_o = ob_types.index(ob_type)
             for expt_name in expt_names:
-                print("%s %s %s" % (date, expt_name, ob_type))
+                print(f"{date} {expt_name} {ob_type}")
                 i_e = expt_names.index(expt_name)
                 mem = 1
                 while mem <= n_mem:
                     memid = str(mem).zfill(4)
                     if ob_type == "u" or ob_type == "v":
-                        obsfile = _os.path.join(datapath, "%s/%s/mem%s/diag_conv_uv_ges.%s.nc4" % (expt_name, date, memid, date))
+                        obsfile = _os.path.join(datapath, f"{expt_name}/{date}/mem{memid}/diag_conv_uv_ges.{date}.nc4")
                     else:
-                        obsfile = _os.path.join(datapath, "%s/%s/mem%s/diag_conv_%s_ges.%s.nc4" % (expt_name, date, memid, ob_type, date))
+                        obsfile = _os.path.join(datapath, f"{expt_name}/{date}/mem{memid}/diag_conv_{ob_type}_ges.{date}.nc4")
 
                     exists = _os.path.exists(obsfile)
                     if not exists:
-                        print("diag file for %s mem%s %s doesn't exist." % (expt_name, str(mem).zfill(4), str(date)))
+                        print(f"diag file for {expt_name} mem{mem:0>4} {date} doesn't exist.")
                         mem = mem + 1
                         break
 


### PR DESCRIPTION
Added some capabilities for observation space ensemble DA diagnostics for RRFS. Two main scripts were added: filter_obs.py and obspace.py. The filter obs script is a function for selecting which observations to use from the diag file. This can filter observations by observation type from the bufr obs table (https://emc.ncep.noaa.gov/mmb/data_processing/prepbufr.doc/table_2.htm) as well as by lat/lon/pressure/error. The obspace.py script computes and plots the observation space ensemble DA diagnostics.