### PR TITLE
Bugfix/use nanmean

### DIFF
--- a/src/pyGSI/ensemble_diags.py
+++ b/src/pyGSI/ensemble_diags.py
@@ -445,7 +445,6 @@ def profile(
                     exists = _os.path.exists(diagfile)
                     if not exists:
                         print(f"diag file for {expt_name} mem{mem:0>4} {date} doesn't exist. Skipping {date}.")
-                        n_skip = n_skip + 1
                         bbreak = True  # need to break here and one loop higher.
                         break
 
@@ -609,14 +608,13 @@ def profile(
     num_obs_total = _np.sum(num_obs_total, axis=2)
     num_obs_assim = _np.sum(num_obs_assim, axis=2)
     # Average over all cycle times (axis=2)
-    n_dates = n_dates - n_skip/n_ob_type  # re-calc n_dates, we may have needed to skip some dates.
-    bias = _np.sum(bias, axis=2) / n_dates
-    rms = _np.sum(rms, axis=2) / n_dates
-    ob_error = _np.sum(ob_error, axis=2) / n_dates
-    std_dev = _np.sum(std_dev, axis=2) / n_dates
-    spread = _np.sum(spread, axis=2) / n_dates
-    total_spread = _np.sum(total_spread, axis=2) / n_dates
-    cr = _np.sum(cr, axis=2) / n_dates
-    ser = _np.sum(ser, axis=2) / n_dates
+    bias = _np.nanmean(bias, axis=2) / n_dates
+    rms = _np.nanmean(rms, axis=2) / n_dates
+    ob_error = _np.nanmean(ob_error, axis=2) / n_dates
+    std_dev = _np.nanmean(std_dev, axis=2) / n_dates
+    spread = _np.nanmean(spread, axis=2) / n_dates
+    total_spread = _np.nanmean(total_spread, axis=2) / n_dates
+    cr = _np.nanmean(cr, axis=2) / n_dates
+    ser = _np.nanmean(ser, axis=2) / n_dates
 
     return levs, levs2, levs1, dates, bias, rms, std_dev, spread, ob_error, total_spread, num_obs_total, num_obs_assim, cr, ser

--- a/src/pyGSI/ensemble_diags.py
+++ b/src/pyGSI/ensemble_diags.py
@@ -608,13 +608,13 @@ def profile(
     num_obs_total = _np.sum(num_obs_total, axis=2)
     num_obs_assim = _np.sum(num_obs_assim, axis=2)
     # Average over all cycle times (axis=2)
-    bias = _np.nanmean(bias, axis=2) / n_dates
-    rms = _np.nanmean(rms, axis=2) / n_dates
-    ob_error = _np.nanmean(ob_error, axis=2) / n_dates
-    std_dev = _np.nanmean(std_dev, axis=2) / n_dates
-    spread = _np.nanmean(spread, axis=2) / n_dates
-    total_spread = _np.nanmean(total_spread, axis=2) / n_dates
-    cr = _np.nanmean(cr, axis=2) / n_dates
-    ser = _np.nanmean(ser, axis=2) / n_dates
+    bias = _np.nanmean(bias, axis=2)
+    rms = _np.nanmean(rms, axis=2)
+    ob_error = _np.nanmean(ob_error, axis=2)
+    std_dev = _np.nanmean(std_dev, axis=2)
+    spread = _np.nanmean(spread, axis=2)
+    total_spread = _np.nanmean(total_spread, axis=2)
+    cr = _np.nanmean(cr, axis=2)
+    ser = _np.nanmean(ser, axis=2)
 
     return levs, levs2, levs1, dates, bias, rms, std_dev, spread, ob_error, total_spread, num_obs_total, num_obs_assim, cr, ser


### PR DESCRIPTION
Bug fix for ensemble DA diagnostic vertical profile calculations. Use numpy.nanmean built in function to compute mean ignoring NaNs. This fixes an issue where points would not plot if an average was taking place which included NaNs.