### PR TITLE
Add custom variable yaml input for plotting capability flexibility

### DIFF
--- a/scripts/mp_plot_conv_diags.py
+++ b/scripts/mp_plot_conv_diags.py
@@ -47,7 +47,7 @@ def _uv_plotting(df, lats, lons, data_type, analysis_use, bias_correction,
             plot_map(lats, lons, data[key], metadata, outdir)
 
 
-def plotting(conv_config, diag_file, data_type, plot_type, outdir):
+def plotting(conv_config, diag_file, data_type, plot_type, var_yaml, outdir):
 
     obsid = conv_config['observation id']
     obsubtype = conv_config['observation subtype']
@@ -105,9 +105,9 @@ def plotting(conv_config, diag_file, data_type, plot_type, outdir):
             data = df[column].to_numpy()
 
             if np.isin('histogram', plot_type):
-                plot_histogram(data, metadata, outdir)
+                plot_histogram(data, metadata, var_yaml, outdir)
             if np.isin('spatial', plot_type):
-                plot_map(lats, lons, data, metadata, outdir)
+                plot_map(lats, lons, data, metadata, var_yaml, outdir)
 
 
 if __name__ == '__main__':
@@ -120,6 +120,8 @@ if __name__ == '__main__':
                     help="Path to yaml file with diag data")
     ap.add_argument("-o", "--outdir",
                     help="Out directory where files will be saved")
+    ap.add_argument("-v", "--varyaml", required=False,
+                    help="Path to yaml file with specific variable information")
 
     myargs = ap.parse_args()
 
@@ -145,10 +147,13 @@ if __name__ == '__main__':
                         "of the plot types you would like to create. "
                         "i.e. ['histogram', 'spatial']")
 
+    variable_yaml = myargs.varyaml if myargs.varyaml else None
+
     p = Pool(processes=nprocs)
     p.map(partial(plotting, diag_file=data_path,
                   data_type=data_type,
                   plot_type=plot_type,
+                  var_yaml=variable_yaml,
                   outdir=outdir), work)
 
     print(datetime.now() - start_time)

--- a/scripts/mp_plot_ozone_diags.py
+++ b/scripts/mp_plot_ozone_diags.py
@@ -11,7 +11,7 @@ from datetime import datetime
 start_time = datetime.now()
 
 
-def plotting(ozone_config, diag_file, data_type, plot_type, outdir):
+def plotting(ozone_config, diag_file, data_type, plot_type, var_yaml, outdir):
 
     analysis_use = ozone_config['analysis use'][0]
     layer = ozone_config['layer'][0]
@@ -55,9 +55,9 @@ def plotting(ozone_config, diag_file, data_type, plot_type, outdir):
         data = df[dict_key][column].to_numpy()
 
     if np.isin('histogram', plot_type):
-        plot_histogram(data, metadata, outdir)
+        plot_histogram(data, metadata, var_yaml, outdir)
     if np.isin('spatial', plot_type):
-        plot_map(lats, lons, data, metadata, outdir)
+        plot_map(lats, lons, data, metadata, var_yaml, outdir)
 
 
 if __name__ == '__main__':
@@ -70,6 +70,8 @@ if __name__ == '__main__':
                     help="Path to yaml file with diag data")
     ap.add_argument("-o", "--outdir",
                     help="Out directory where files will be saved")
+    ap.add_argument("-v", "--varyaml", required=False,
+                    help="Path to yaml file with specific variable information")
 
     myargs = ap.parse_args()
 
@@ -94,11 +96,14 @@ if __name__ == '__main__':
                         "Please add key 'plot types' to yaml and list "
                         "of the plot types you would like to create. "
                         "i.e. ['histogram', 'spatial']")
+        
+    variable_yaml = myargs.varyaml if myargs.varyaml else None
 
     p = Pool(processes=nprocs)
     p.map(partial(plotting, diag_file=data_path,
                   data_type=data_type,
                   plot_type=plot_type,
+                  var_yaml=variable_yaml,
                   outdir=outdir), work)
 
     print(datetime.now() - start_time)

--- a/scripts/mp_plot_ozone_diags.py
+++ b/scripts/mp_plot_ozone_diags.py
@@ -96,7 +96,7 @@ if __name__ == '__main__':
                         "Please add key 'plot types' to yaml and list "
                         "of the plot types you would like to create. "
                         "i.e. ['histogram', 'spatial']")
-        
+
     variable_yaml = myargs.varyaml if myargs.varyaml else None
 
     p = Pool(processes=nprocs)

--- a/scripts/mp_plot_sat_diags.py
+++ b/scripts/mp_plot_sat_diags.py
@@ -79,7 +79,7 @@ if __name__ == '__main__':
                     help="Path to yaml file with specific variable information")
 
     myargs = ap.parse_args()
-    
+
     if myargs.nprocs:
         nprocs = int(myargs.nprocs)
     else:
@@ -90,7 +90,7 @@ if __name__ == '__main__':
 
     with open(diag_yaml, 'r') as file:
         parsed_diag_yaml = yaml.load(file, Loader=yaml.FullLoader)
-        
+
     work = parsed_diag_yaml['diagnostic']['radiance']
     data_type = parsed_diag_yaml['diagnostic']['data type']
     data_path = parsed_diag_yaml['diagnostic']['path']
@@ -101,9 +101,9 @@ if __name__ == '__main__':
                         "Please add key 'plot types' to yaml and list "
                         "of the plot types you would like to create. "
                         "i.e. ['histogram', 'spatial']")
-        
+
     variable_yaml = myargs.varyaml if myargs.varyaml else None
-            
+
     p = Pool(processes=nprocs)
     p.map(partial(plotting, diag_file=data_path,
                   data_type=data_type,

--- a/src/pyGSI/plot_diags.py
+++ b/src/pyGSI/plot_diags.py
@@ -265,7 +265,7 @@ def _no_data_histogram(data, metadata, outdir):
     return
 
 
-def _create_hist_plot(data, metadata, outdir, color, legend,
+def _create_hist_plot(data, metadata, var_yaml, outdir, color, legend,
                       grid, plot_mean, plot_zero, title,
                       date_title, xlabel, ylabel,
                       annotate_stats):
@@ -280,7 +280,8 @@ def _create_hist_plot(data, metadata, outdir, color, legend,
     eval_type = 'diff' if metadata['Diag Type'] in \
         ['omf', 'oma'] else 'magnitude'
     varspecs = VariableSpecs(variable=spec_variable,
-                             eval_type=eval_type)
+                             eval_type=eval_type,
+                             var_yaml=var_yaml)
     metadata['Variable'] = varspecs.name
 
     # Plot special histogram for if len of data is 0 or 1
@@ -407,7 +408,7 @@ def _no_data_map(domain, projection, metadata, outdir):
 
 
 def _create_map_plot(lats, lons, data, metadata,
-                     outdir, domain, projection,
+                     var_yaml, outdir, domain, projection,
                      title, date_title, xlabel,
                      ylabel, annotate_stats,
                      colorbar, cbar_label, grid):
@@ -420,7 +421,8 @@ def _create_map_plot(lats, lons, data, metadata,
     spec_variable = _varspecs_name(metadata['Variable'])
 
     varspecs = VariableSpecs(variable=spec_variable,
-                             eval_type=eval_type)
+                             eval_type=eval_type,
+                             var_yaml=var_yaml)
     metadata['Variable'] = varspecs.name
 
     # If no data, plot empty map
@@ -502,7 +504,7 @@ def _create_map_plot(lats, lons, data, metadata,
     return
 
 
-def plot_histogram(data, metadata, outdir='./', color='tab:blue',
+def plot_histogram(data, metadata, var_yaml, outdir='./', color='tab:blue',
                    legend=True, grid=False, plot_mean=True,
                    plot_zero=True, title=None, date_title=None,
                    xlabel=None, ylabel=None,
@@ -544,16 +546,16 @@ def plot_histogram(data, metadata, outdir='./', color='tab:blue',
             metadata['Anl Use Type'] = anl_type
 
             _create_hist_plot(data[anl_type],
-                              metadata, outdir,
-                              color, legend, grid,
-                              plot_mean, plot_zero,
+                              metadata, var_yaml, 
+                              outdir, color, legend,
+                              grid, plot_mean, plot_zero,
                               title, date_title,
                               xlabel, ylabel,
                               annotate_stats)
 
     else:
         metadata['Anl Use Type'] = None
-        _create_hist_plot(data, metadata, outdir, color,
+        _create_hist_plot(data, metadata, var_yaml, outdir, color,
                           legend, grid, plot_mean, plot_zero,
                           title, date_title, xlabel, ylabel,
                           annotate_stats)
@@ -561,7 +563,7 @@ def plot_histogram(data, metadata, outdir='./', color='tab:blue',
     return
 
 
-def plot_map(lats, lons, data, metadata, outdir='./', domain='global',
+def plot_map(lats, lons, data, metadata, var_yaml, outdir='./', domain='global',
              projection='plcarr', title=None, date_title=None,
              xlabel=None, ylabel=None, annotate_stats=True, colorbar=True,
              cbar_label=None, grid=False):
@@ -604,7 +606,7 @@ def plot_map(lats, lons, data, metadata, outdir='./', domain='global',
             metadata['Anl Use Type'] = anl_type
 
             _create_map_plot(lats[anl_type], lons[anl_type],
-                             data[anl_type], metadata,
+                             data[anl_type], metadata, var_yaml,
                              outdir, domain, projection,
                              title, date_title, xlabel,
                              ylabel, annotate_stats,
@@ -612,9 +614,9 @@ def plot_map(lats, lons, data, metadata, outdir='./', domain='global',
 
     else:
         metadata['Anl Use Type'] = None
-        _create_map_plot(lats, lons, data, metadata, outdir,
-                         domain, projection, title, date_title,
-                         xlabel, ylabel, annotate_stats,
+        _create_map_plot(lats, lons, data, metadata, var_yaml, 
+                         outdir, domain, projection, title,
+                         date_title, xlabel, ylabel, annotate_stats,
                          colorbar, cbar_label, grid)
 
     return

--- a/src/pyGSI/plot_diags.py
+++ b/src/pyGSI/plot_diags.py
@@ -546,7 +546,7 @@ def plot_histogram(data, metadata, var_yaml, outdir='./', color='tab:blue',
             metadata['Anl Use Type'] = anl_type
 
             _create_hist_plot(data[anl_type],
-                              metadata, var_yaml, 
+                              metadata, var_yaml,
                               outdir, color, legend,
                               grid, plot_mean, plot_zero,
                               title, date_title,
@@ -614,7 +614,7 @@ def plot_map(lats, lons, data, metadata, var_yaml, outdir='./', domain='global',
 
     else:
         metadata['Anl Use Type'] = None
-        _create_map_plot(lats, lons, data, metadata, var_yaml, 
+        _create_map_plot(lats, lons, data, metadata, var_yaml,
                          outdir, domain, projection, title,
                          date_title, xlabel, ylabel, annotate_stats,
                          colorbar, cbar_label, grid)


### PR DESCRIPTION
An issue arose where a user wanted to utilize `PyGSI`'s plotting capabilities for high peaking satellite channels and ran into an issue where none of their data fell within the preset variable bounds used by `EMCPy`'s default variable yaml: https://github.com/NOAA-EMC/emcpy/blob/develop/src/emcpy/cfg/var_defaults.yaml

You can see the problem in the figure below:
![image](https://user-images.githubusercontent.com/69815622/227252670-486a2412-ebc3-4a73-8d81-d5729138e3f0.png)

The current version of `PyGSI`'s `plot_diags.py` only uses the default variables in `EMCPy`. This PR adds capabilities to add a custom input variable yaml so users can have control if looking at a specified variable.

An example shows that if we create a test yaml for these purpose's where I set the range from 0-400 as so:
```
brightness temperature:
  cmap: gist_earth
  contour interval: 5
  diff contour interval: 0.5
  diff range: [-5, 5]
  name: brightness temperature
  range: [0, 400]
  short name: bt
  units: K
  variable type: radiance
```

the changes can be seen in this figure:

![image](https://user-images.githubusercontent.com/69815622/227254742-500aa28f-1627-4942-88ff-04f66ff013c2.png)

The following code changes allow for in the input of a custom variable yaml so users can have control over specific plotting details.